### PR TITLE
Buildbot profiler now runs under python 3.6

### DIFF
--- a/buildbot_profiler/__init__.py
+++ b/buildbot_profiler/__init__.py
@@ -7,4 +7,4 @@ from .api import Api
 # create the interface for the setuptools entry point
 ep = Application(__name__, "Buildbot profiler")
 api = Api(ep)
-ep.resource.putChild(unicode2bytes("api"), api.app.resource())
+ep.resource.putChild(b"api", api.app.resource())

--- a/buildbot_profiler/__init__.py
+++ b/buildbot_profiler/__init__.py
@@ -1,4 +1,5 @@
 from buildbot.www.plugin import Application
+from buildbot.util import unicode2bytes
 
 from .api import Api
 
@@ -6,4 +7,4 @@ from .api import Api
 # create the interface for the setuptools entry point
 ep = Application(__name__, "Buildbot profiler")
 api = Api(ep)
-ep.resource.putChild("api", api.app.resource())
+ep.resource.putChild(unicode2bytes("api"), api.app.resource())

--- a/buildbot_profiler/api.py
+++ b/buildbot_profiler/api.py
@@ -5,7 +5,7 @@ import json
 import os
 import signal
 import sys
-import thread
+import threading
 import time
 from signal import ITIMER_PROF, ITIMER_REAL, ITIMER_VIRTUAL, setitimer
 
@@ -91,7 +91,7 @@ class Collector(object):
             reactor.callFromThread(self.finish_callback)
             return
 
-        current_tid = thread.get_ident()
+        current_tid = threading.get_ident()
         threads = {}
 
         for tid, frame in iteritems(sys._current_frames()):

--- a/buildbot_profiler/app.py
+++ b/buildbot_profiler/app.py
@@ -1,12 +1,14 @@
 import os
 import sys
 
+from __future__ import print_function
+
 from twisted.internet import reactor
 from twisted.python import log
 from twisted.web.server import Site
 
 from buildbot_profiler import ep
-from buildbot.util import unicode2bytes
+
 
 def main():
     port = os.environ.get("PORT", 8080)

--- a/buildbot_profiler/app.py
+++ b/buildbot_profiler/app.py
@@ -6,12 +6,12 @@ from twisted.python import log
 from twisted.web.server import Site
 
 from buildbot_profiler import ep
-
+from buildbot.util import unicode2bytes
 
 def main():
     port = os.environ.get("PORT", 8080)
 
-    print "running on http://localhost:{}".format(port)
+    print("running on http://localhost:{}".format(port))
     log.startLogging(sys.stdout)
     ep.resource.putChild('profiler', ep.resource)
     reactor.listenTCP(port, Site(ep.resource), interface='localhost')


### PR DESCRIPTION
We don't have any way to test these under python 2.7 since we don't have that environment, but the changes were minimal. I would note that the call to unicode2bytes("api") is actually needed in a host of buildbot samples such as nested example. 